### PR TITLE
fix: docker compose on testdrive showing an error of "Unsupported config option"

### DIFF
--- a/testdrive/docker-compose.yml
+++ b/testdrive/docker-compose.yml
@@ -1,3 +1,5 @@
+version: "3.7"
+
 services:
   scrolls:
     image: ghcr.io/txpipe/scrolls:latest


### PR DESCRIPTION
Fixing error when trying to execute `docker-compose up` or `docker-compose config`. Because of this it's not starting