### PR TITLE
feat: Add 'pool by stake address' collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Scrolls is a pipeline that takes block data as input and outputs DB update comma
   - [ ] Address by UTXO
   - [ ] Tx CBOR by UTXO
   - [ ] Tx CBOR by Address
-  - [ ] Pool Id by Stake Address
+  - [x] Pool Id by Stake Address
   - [ ] Pool Metadata by Pool Id
   - [ ] Chain Parameters by Epoch
   - [ ] UTXOs by Asset

--- a/src/bin/scrolls/daemon.rs
+++ b/src/bin/scrolls/daemon.rs
@@ -35,6 +35,7 @@ impl FromConfig<SourceConfig> for sources::Plugin {
 pub enum ReducerConfig {
     UtxoByAddress(reducers::utxo_by_address::Config),
     PointByTx(reducers::point_by_tx::Config),
+    PoolByStake(reducers::pool_by_stake::Config),
 }
 
 impl FromConfig<ReducerConfig> for reducers::Plugin {
@@ -46,6 +47,7 @@ impl FromConfig<ReducerConfig> for reducers::Plugin {
         match other {
             ReducerConfig::UtxoByAddress(c) => reducers::IntoPlugin::plugin(c, chain, intersect),
             ReducerConfig::PointByTx(c) => reducers::IntoPlugin::plugin(c, chain, intersect),
+            ReducerConfig::PoolByStake(c) => reducers::IntoPlugin::plugin(c, chain, intersect),
         }
     }
 }

--- a/src/model.rs
+++ b/src/model.rs
@@ -54,6 +54,7 @@ pub enum MultiEraBlock {
 pub type Set = String;
 pub type Member = String;
 pub type Key = String;
+pub type Value = String;
 pub type Timestamp = u64;
 
 #[derive(Debug)]

--- a/src/model.rs
+++ b/src/model.rs
@@ -53,10 +53,13 @@ pub enum MultiEraBlock {
 
 pub type Set = String;
 pub type Member = String;
+pub type Key = String;
+pub type Timestamp = u64;
 
 #[derive(Debug)]
 pub enum CRDTCommand {
     TwoPhaseSetAdd(Set, Member),
     TwoPhaseSetRemove(Set, Member),
     GrowOnlySetAdd(Set, Member),
+    LastWriteWins(Key, Value, Timestamp),
 }

--- a/src/reducers/mod.rs
+++ b/src/reducers/mod.rs
@@ -3,6 +3,7 @@ use gasket::messaging::{InputPort, OutputPort};
 use crate::{bootstrap, crosscut, model};
 
 pub mod point_by_tx;
+pub mod pool_by_stake;
 pub mod utxo_by_address;
 
 pub trait Pluggable {
@@ -14,6 +15,7 @@ pub trait Pluggable {
 pub enum Plugin {
     UtxoByAddress(utxo_by_address::Worker),
     PointByTx(point_by_tx::Worker),
+    PoolByStake(pool_by_stake::Worker),
 }
 
 impl Plugin {
@@ -21,6 +23,7 @@ impl Plugin {
         match self {
             Plugin::UtxoByAddress(x) => x.borrow_input_port(),
             Plugin::PointByTx(x) => x.borrow_input_port(),
+            Plugin::PoolByStake(x) => x.borrow_input_port(),
         }
     }
 
@@ -28,6 +31,7 @@ impl Plugin {
         match self {
             Plugin::UtxoByAddress(x) => x.borrow_output_port(),
             Plugin::PointByTx(x) => x.borrow_output_port(),
+            Plugin::PoolByStake(x) => x.borrow_output_port(),
         }
     }
 
@@ -35,6 +39,7 @@ impl Plugin {
         match self {
             Plugin::UtxoByAddress(x) => x.spawn(pipeline),
             Plugin::PointByTx(x) => x.spawn(pipeline),
+            Plugin::PoolByStake(x) => x.spawn(pipeline),
         }
     }
 }

--- a/src/reducers/pool_by_stake.rs
+++ b/src/reducers/pool_by_stake.rs
@@ -1,0 +1,140 @@
+use gasket::{
+    error::AsWorkError,
+    runtime::{spawn_stage, WorkOutcome},
+};
+use pallas::ledger::primitives::{alonzo, byron};
+use pallas::{
+    crypto::hash::Hash,
+    ledger::primitives::alonzo::{PoolKeyhash, StakeCredential},
+};
+use serde::Deserialize;
+
+use crate::{bootstrap, crosscut, model};
+
+type InputPort = gasket::messaging::InputPort<model::ChainSyncCommandEx>;
+type OutputPort = gasket::messaging::OutputPort<model::CRDTCommand>;
+
+#[derive(Deserialize)]
+pub struct Config {
+    pub key_prefix: Option<String>,
+}
+
+pub struct Worker {
+    config: Config,
+    input: InputPort,
+    output: OutputPort,
+    ops_count: gasket::metrics::Counter,
+}
+
+impl Worker {
+    fn send_key_write(
+        &mut self,
+        cred: &StakeCredential,
+        pool: &PoolKeyhash,
+        slot: u64,
+    ) -> Result<(), gasket::error::Error> {
+        let hash = match cred {
+            StakeCredential::AddrKeyhash(x) => x.to_string(),
+            StakeCredential::Scripthash(x) => x.to_string(),
+        };
+
+        let key = match &self.config.key_prefix {
+            Some(prefix) => format!("{}.{}", prefix, hash),
+            None => hash.to_string(),
+        };
+
+        let value = pool.to_string();
+
+        let crdt = model::CRDTCommand::LastWriteWins(key, value, slot);
+
+        self.output.send(gasket::messaging::Message::from(crdt))?;
+        self.ops_count.inc(1);
+
+        Ok(())
+    }
+
+    fn reduce_alonzo_compatible_tx(
+        &mut self,
+        slot: u64,
+        tx: &alonzo::TransactionBody,
+    ) -> Result<(), gasket::error::Error> {
+        let tx_hash = tx.to_hash();
+
+        tx.iter()
+            .filter_map(|b| match b {
+                alonzo::TransactionBodyComponent::Certificates(c) => Some(c),
+                _ => None,
+            })
+            .flat_map(|c| c.iter())
+            .filter_map(|c| match c {
+                alonzo::Certificate::StakeDelegation(cred, pool) => Some((cred, pool)),
+                _ => None,
+            })
+            .map(|(cred, pool)| self.send_key_write(cred, pool, slot))
+            .collect()
+    }
+
+    fn reduce_block(&mut self, block: &model::MultiEraBlock) -> Result<(), gasket::error::Error> {
+        match block {
+            model::MultiEraBlock::Byron(_) => Ok(()),
+            model::MultiEraBlock::AlonzoCompatible(block) => {
+                x.1.transaction_bodies
+                    .iter()
+                    .map(|tx| self.reduce_alonzo_compatible_tx(block.1.header.header_body.slot, tx))
+                    .collect()
+            }
+        }
+    }
+}
+
+impl gasket::runtime::Worker for Worker {
+    fn metrics(&self) -> gasket::metrics::Registry {
+        gasket::metrics::Builder::new()
+            .with_counter("ops_count", &self.ops_count)
+            .build()
+    }
+
+    fn work(&mut self) -> gasket::runtime::WorkResult {
+        let msg = self.input.recv()?;
+
+        match msg.payload {
+            model::ChainSyncCommandEx::RollForward(block) => self.reduce_block(&block)?,
+            model::ChainSyncCommandEx::RollBack(point) => {
+                log::warn!("rollback requested for {:?}", point);
+            }
+        }
+
+        Ok(WorkOutcome::Partial)
+    }
+}
+
+impl super::Pluggable for Worker {
+    fn borrow_input_port(&mut self) -> &'_ mut InputPort {
+        &mut self.input
+    }
+
+    fn borrow_output_port(&mut self) -> &'_ mut OutputPort {
+        &mut self.output
+    }
+
+    fn spawn(self, pipeline: &mut bootstrap::Pipeline) {
+        pipeline.register_stage("pool_by_address", spawn_stage(self, Default::default()));
+    }
+}
+
+impl super::IntoPlugin for Config {
+    fn plugin(
+        self,
+        chain: &crosscut::ChainWellKnownInfo,
+        _intersect: &crosscut::IntersectConfig,
+    ) -> super::Plugin {
+        let worker = Worker {
+            config: self,
+            input: Default::default(),
+            output: Default::default(),
+            ops_count: Default::default(),
+        };
+
+        super::Plugin::PoolByStake(worker)
+    }
+}

--- a/src/storage/redis.rs
+++ b/src/storage/redis.rs
@@ -51,6 +51,13 @@ impl gasket::runtime::Worker for Worker {
                     .sadd(format!("{}.ts", key), value)
                     .or_work_err()?;
             }
+            model::CRDTCommand::LastWriteWins(key, value, timestamp) => {
+                self.connection
+                    .as_mut()
+                    .unwrap()
+                    .zadd(key, value, timestamp)
+                    .or_work_err()?;
+            }
         };
 
         Ok(WorkOutcome::Partial)

--- a/testdrive/daemon.toml
+++ b/testdrive/daemon.toml
@@ -10,6 +10,10 @@ key_prefix = "c1"
 type = "PointByTx"
 key_prefix = "c2"
 
+[[reducers]]
+type = "PoolByStake"
+key_prefix = "c3"
+
 [storage]
 type = "Redis"
 connection_params = "redis://redis:6379"


### PR DESCRIPTION
This new collection introduces the following lookup table:

hex(stake_address key_hash | script_hash) => hex(pool_hash)

It uses a `LastWriteWins` CRDT, sorted by the slot of the certificate.