### PR TITLE
[utxo by address] - Filter implemented

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,8 @@ address = "relays-new.cardano-mainnet.iohk.io:3001"
 type = "UtxoByAddress"
 # you can optionally prefix the keys in the collection
 key_prefix = "c1"
+# you can optionally only process UTXO from a set of predetermined addresses
+filter = ["addr1qy8jecz3nal788f8t2zy6vj2l9ply3trpnkn2xuvv5rgu4m7y853av2nt8wc33agu3kuakvg0kaee0tfqhgelh2eeyyqgxmxw3"]
 
 # enable the "Point by Tx" collection
 [[reducers]]

--- a/src/reducers/utxo_by_address.rs
+++ b/src/reducers/utxo_by_address.rs
@@ -24,16 +24,13 @@ impl Reducer {
         tx_idx: usize,
         output: &mut super::OutputPort,
     ) -> Result<(), gasket::error::Error> {
-        if self.config.filter.is_some() {
-            match self.config.filter.as_ref().unwrap().binary_search(&address.to_string()) {
-                Ok(_) => {
-                    log::info!("Address '{}' added with UTXO data", address);
-                }
-                Err(_) => {
-                    return Ok(());
-                }
+        if let Some(addresses) = &self.config.filter {
+            if let Err(_) = addresses.binary_search(&address.to_string())
+            {
+                return Ok(());
             }
         }
+
         let key = match &self.config.key_prefix {
             Some(prefix) => format!("{}.{}", prefix, address),
             None => address.to_string(),

--- a/src/reducers/utxo_by_address.rs
+++ b/src/reducers/utxo_by_address.rs
@@ -8,6 +8,7 @@ use crate::{crosscut, model};
 #[derive(Deserialize)]
 pub struct Config {
     pub key_prefix: Option<String>,
+    pub filter: Option<Vec<String>>
 }
 
 pub struct Reducer {
@@ -23,6 +24,16 @@ impl Reducer {
         tx_idx: usize,
         output: &mut super::OutputPort,
     ) -> Result<(), gasket::error::Error> {
+        if self.config.filter.is_some() {
+            match self.config.filter.as_ref().unwrap().binary_search(&address.to_string()) {
+                Ok(_) => {
+                    log::info!("Address '{}' added with UTXO data", address);
+                }
+                Err(_) => {
+                    return Ok(());
+                }
+            }
+        }
         let key = match &self.config.key_prefix {
             Some(prefix) => format!("{}.{}", prefix, address),
             None => address.to_string(),


### PR DESCRIPTION
First PR to an open source project!
I spent some time to understand the whole project flow. Please keep in mind I am relatively new to Rust.

So the address filter for the UtxoByAddress reducer has been implemented (Issue #14). How to use it is showed in the exemple .toml

The filter is optional.

I've decided to implement the functionality directly into the "send_set_add" instead of implementing it twice separately in the reduce_byron/alonzo_tx.

I went with the "binary_search" as it seems to be good fast option (https://stackoverflow.com/questions/67525751/what-is-the-fastest-way-to-check-if-something-exist-in-a-vector-in-rust).

I hope it helps! That ain't much but consider it as my entry implication to the project. Feedbacks are ofc more than welcome ;)