### PR TITLE
chore: Add `unstable` feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,4 +33,5 @@ thiserror = "1.0.30"
 redis = "0.21.5"
 
 [features]
+unstable = []
 default = []

--- a/src/bin/scrolls/daemon.rs
+++ b/src/bin/scrolls/daemon.rs
@@ -33,13 +33,18 @@ pub enum ReducerConfig {
     UtxoByAddress(reducers::utxo_by_address::Config),
     PointByTx(reducers::point_by_tx::Config),
     PoolByStake(reducers::pool_by_stake::Config),
-    TotalTransactionsCount(reducers::total_transactions_count::Config),
 
+    #[cfg(feature = "unstable")]
+    TotalTransactionsCount(reducers::total_transactions_count::Config),
+    #[cfg(feature = "unstable")]
     TransactionsCountByEpoch(reducers::transactions_count_by_epoch::Config),
+    #[cfg(feature = "unstable")]
     TransactionsCountByContractAddress(reducers::transactions_count_by_contract_address::Config),
+    #[cfg(feature = "unstable")]
     TransactionsCountByContractAddressByEpoch(
         reducers::transactions_count_by_contract_address_by_epoch::Config,
     ),
+    #[cfg(feature = "unstable")]
     TotalTransactionsCountByContractAddresses(
         reducers::total_transactions_count_by_contract_addresses::Config,
     ),
@@ -51,10 +56,16 @@ impl ReducerConfig {
             ReducerConfig::UtxoByAddress(c) => c.plugin(chain),
             ReducerConfig::PointByTx(c) => c.plugin(),
             ReducerConfig::PoolByStake(c) => c.plugin(),
+
+            #[cfg(feature = "unstable")]
             ReducerConfig::TotalTransactionsCount(c) => c.plugin(),
+            #[cfg(feature = "unstable")]
             ReducerConfig::TransactionsCountByEpoch(c) => c.plugin(chain),
+            #[cfg(feature = "unstable")]
             ReducerConfig::TransactionsCountByContractAddress(c) => c.plugin(chain),
+            #[cfg(feature = "unstable")]
             ReducerConfig::TransactionsCountByContractAddressByEpoch(c) => c.plugin(chain),
+            #[cfg(feature = "unstable")]
             ReducerConfig::TotalTransactionsCountByContractAddresses(c) => c.plugin(),
         }
     }

--- a/src/reducers/mod.rs
+++ b/src/reducers/mod.rs
@@ -10,23 +10,35 @@ type OutputPort = gasket::messaging::OutputPort<model::CRDTCommand>;
 
 pub mod point_by_tx;
 pub mod pool_by_stake;
-pub mod total_transactions_count;
-pub mod total_transactions_count_by_contract_addresses;
-pub mod transactions_count_by_contract_address;
-pub mod transactions_count_by_contract_address_by_epoch;
-pub mod transactions_count_by_epoch;
 pub mod utxo_by_address;
+
+#[cfg(feature = "unstable")]
+pub mod total_transactions_count;
+#[cfg(feature = "unstable")]
+pub mod total_transactions_count_by_contract_addresses;
+#[cfg(feature = "unstable")]
+pub mod transactions_count_by_contract_address;
+#[cfg(feature = "unstable")]
+pub mod transactions_count_by_contract_address_by_epoch;
+#[cfg(feature = "unstable")]
+pub mod transactions_count_by_epoch;
 
 pub enum Plugin {
     UtxoByAddress(utxo_by_address::Reducer),
     PointByTx(point_by_tx::Reducer),
     PoolByStake(pool_by_stake::Reducer),
+
+    #[cfg(feature = "unstable")]
     TotalTransactionsCount(total_transactions_count::Reducer),
+    #[cfg(feature = "unstable")]
     TransactionsCountByEpoch(transactions_count_by_epoch::Reducer),
+    #[cfg(feature = "unstable")]
     TransactionsCountByContractAddress(transactions_count_by_contract_address::Reducer),
+    #[cfg(feature = "unstable")]
     TransactionsCountByContractAddressByEpoch(
         transactions_count_by_contract_address_by_epoch::Reducer,
     ),
+    #[cfg(feature = "unstable")]
     TotalTransactionsCountByContractAddresses(
         total_transactions_count_by_contract_addresses::Reducer,
     ),
@@ -42,10 +54,16 @@ impl Plugin {
             Plugin::UtxoByAddress(x) => x.reduce_block(block, output),
             Plugin::PointByTx(x) => x.reduce_block(block, output),
             Plugin::PoolByStake(x) => x.reduce_block(block, output),
+
+            #[cfg(feature = "unstable")]
             Plugin::TotalTransactionsCount(x) => x.reduce_block(block, output),
+            #[cfg(feature = "unstable")]
             Plugin::TransactionsCountByEpoch(x) => x.reduce_block(block, output),
+            #[cfg(feature = "unstable")]
             Plugin::TransactionsCountByContractAddress(x) => x.reduce_block(block, output),
+            #[cfg(feature = "unstable")]
             Plugin::TransactionsCountByContractAddressByEpoch(x) => x.reduce_block(block, output),
+            #[cfg(feature = "unstable")]
             Plugin::TotalTransactionsCountByContractAddresses(x) => x.reduce_block(block, output),
         }
     }


### PR DESCRIPTION
In this PR we add an `unstable` feature flag to enable experimentation of new reducers without constantly introducing breaking changes on the default release.

cc @matiwinnetou, this will require you to use `cargo build --features unstable` to enable the latest reducers.