### PR TITLE
transactions count by script hash

### DIFF
--- a/src/reducers/mod.rs
+++ b/src/reducers/mod.rs
@@ -26,6 +26,8 @@ pub mod transactions_count_by_address;
 pub mod transactions_count_by_address_by_epoch;
 #[cfg(feature = "unstable")]
 pub mod transactions_count_by_epoch;
+#[cfg(feature = "unstable")]
+pub mod transactions_count_by_script_hash;
 
 #[derive(Deserialize)]
 #[serde(tag = "type")]
@@ -48,6 +50,8 @@ pub enum Config {
     TotalTransactionsCountByAddresses(total_transactions_count_by_addresses::Config),
     #[cfg(feature = "unstable")]
     BalanceByAddress(balance_by_address::Config),
+    #[cfg(feature = "unstable")]
+    TransactionsCountByScriptHash(transactions_count_by_script_hash::Config),
 }
 
 impl Config {
@@ -75,6 +79,8 @@ impl Config {
             Config::TotalTransactionsCountByAddresses(c) => c.plugin(),
             #[cfg(feature = "unstable")]
             Config::BalanceByAddress(c) => c.plugin(chain, policy),
+            #[cfg(feature = "unstable")]
+            Config::TransactionsCountByScriptHash(c) => c.plugin(),
         }
     }
 }
@@ -134,6 +140,8 @@ pub enum Reducer {
     TotalTransactionsCountByAddresses(total_transactions_count_by_addresses::Reducer),
     #[cfg(feature = "unstable")]
     BalanceByAddress(balance_by_address::Reducer),
+    #[cfg(feature = "unstable")]
+    TransactionsCountByScriptHash(transactions_count_by_script_hash::Reducer),
 }
 
 impl Reducer {
@@ -162,6 +170,8 @@ impl Reducer {
             Reducer::TotalTransactionsCountByAddresses(x) => x.reduce_block(block, output),
             #[cfg(feature = "unstable")]
             Reducer::BalanceByAddress(x) => x.reduce_block(block, ctx, output),
+            #[cfg(feature = "unstable")]
+            Reducer::TransactionsCountByScriptHash(x) => x.reduce_block(block, output),
         }
     }
 }

--- a/src/reducers/transactions_count_by_script_hash.rs
+++ b/src/reducers/transactions_count_by_script_hash.rs
@@ -1,0 +1,67 @@
+use pallas::ledger::traverse::{Feature, MultiEraBlock};
+use serde::Deserialize;
+
+use crate::model;
+
+use pallas::crypto::hash::Hash;
+
+use pallas::ledger::primitives::ToHash;
+
+#[derive(Deserialize)]
+pub struct Config {
+    pub key_prefix: Option<String>,
+}
+
+pub struct Reducer {
+    config: Config,
+}
+
+impl Reducer {
+    fn send_count(
+        &mut self,
+        hash: Hash<28>,
+        output: &mut super::OutputPort,
+    ) -> Result<(), gasket::error::Error> {
+        let key = match &self.config.key_prefix {
+            Some(prefix) => format!("{}.{}", prefix, hash.to_string()),
+            None => format!("{}", hash.to_string()),
+        };
+
+        let crdt = model::CRDTCommand::PNCounter(key, 1);
+        output.send(gasket::messaging::Message::from(crdt))?;
+
+        Ok(())
+    }
+
+    pub fn reduce_block(
+        &mut self,
+        block: &MultiEraBlock,
+        output: &mut super::OutputPort,
+    ) -> Result<(), gasket::error::Error> {
+        if block.era().has_feature(Feature::SmartContracts) {
+            for tx in block.txs() {
+                let maybe_plutus_scripts = &&tx.as_alonzo().unwrap().transaction_witness_set.plutus_script;
+
+                if let Some(plutus_scripts) = maybe_plutus_scripts {
+                    for plutus_script in plutus_scripts.iter() {
+                        let hash = plutus_script.to_hash();
+        
+                        self.send_count(hash, output)?;
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl Config {
+    pub fn plugin(self) -> super::Reducer {
+        let reducer = Reducer {
+            config: self,
+        };
+
+        super::Reducer::TransactionsCountByScriptHash(reducer)
+    }
+}


### PR DESCRIPTION
This is transactions count by script hash PR, unfortunately there is a bug somewhere that hash computed on plutus script is not the same we should expect.

Good example is jpg.store where:
```
https://cardanoscan.io/address/addr1w999n67e86jn6xal07pzxtrmqynspgx0fwmcmpua4wc6yzsxpljz3
```
this is actually the hash:
```
714a59ebd93ea53d1bbf7f82232c7b012700a0cf4bb78d879dabb1a20a
```