### PR TITLE
feat: Implement pipeline-wide policy config

### DIFF
--- a/src/bin/scrolls/daemon.rs
+++ b/src/bin/scrolls/daemon.rs
@@ -36,6 +36,7 @@ struct ConfigRoot {
     storage: storage::Config,
     intersect: crosscut::IntersectConfig,
     chain: Option<ChainConfig>,
+    policy: Option<crosscut::policies::RuntimePolicy>,
 }
 
 impl ConfigRoot {
@@ -78,12 +79,13 @@ pub fn run(args: &ArgMatches) -> Result<(), scrolls::Error> {
         .map_err(|err| scrolls::Error::ConfigError(format!("{:?}", err)))?;
 
     let chain = config.chain.unwrap_or_default().into();
+    let policy = config.policy.unwrap_or_default().into();
 
     let source = config.source.bootstrapper(&chain, &config.intersect);
 
     let enrich = config.enrich.unwrap_or_default().bootstrapper();
 
-    let reducer = reducers::Bootstrapper::new(config.reducers, &chain);
+    let reducer = reducers::Bootstrapper::new(config.reducers, &chain, &policy);
 
     let storage = config.storage.plugin(&chain, &config.intersect);
 

--- a/src/crosscut/policies.rs
+++ b/src/crosscut/policies.rs
@@ -1,56 +1,63 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Serialize, Deserialize)]
-pub struct ReducerPolicy {
-    skip_missing_data: Option<bool>,
-    skip_cbor_errors: Option<bool>,
-    skip_ledger_errors: Option<bool>,
-    skip_all_errors: Option<bool>,
+use crate::Error;
+
+#[derive(Clone, Serialize, Deserialize, PartialEq, PartialOrd)]
+pub enum ErrorAction {
+    Skip,
+    Warn,
+    Default,
+}
+
+impl Default for ErrorAction {
+    fn default() -> Self {
+        ErrorAction::Default
+    }
+}
+
+#[derive(Clone, Serialize, Deserialize, Default)]
+pub struct RuntimePolicy {
+    missing_data: Option<ErrorAction>,
+    cbor_errors: Option<ErrorAction>,
+    ledger_errors: Option<ErrorAction>,
+    any_error: Option<ErrorAction>,
+}
+
+#[inline]
+fn handle_error<T>(err: Error, action: &Option<ErrorAction>) -> Result<Option<T>, crate::Error> {
+    match action {
+        Some(ErrorAction::Skip) => Ok(None),
+        Some(ErrorAction::Warn) => {
+            log::warn!("{}", err);
+            Ok(None)
+        }
+        _ => Err(err),
+    }
 }
 
 pub trait AppliesPolicy {
     type Value;
 
-    fn apply_policy(
-        self,
-        policy: &Option<ReducerPolicy>,
-    ) -> Result<Option<Self::Value>, crate::Error>;
+    fn apply_policy(self, policy: &RuntimePolicy) -> Result<Option<Self::Value>, crate::Error>;
 }
 
 impl<T> AppliesPolicy for Result<T, crate::Error> {
     type Value = T;
 
-    fn apply_policy(
-        self,
-        policy: &Option<ReducerPolicy>,
-    ) -> Result<Option<Self::Value>, crate::Error> {
+    fn apply_policy(self, policy: &RuntimePolicy) -> Result<Option<Self::Value>, crate::Error> {
         match self {
             Ok(t) => Ok(Some(t)),
             Err(err) => {
-
-                if matches!(policy, None) {
-                    return Err(err);
+                // apply generic error policy if we have one
+                if matches!(policy.any_error, Some(_)) {
+                    return handle_error(err, &policy.any_error);
                 }
 
-                let policy = policy.as_ref().unwrap();
-
-                if policy.skip_all_errors.unwrap_or(false) {
-                    return Ok(None);
-                }
-
+                // apply specific actions for each type of error
                 match &err {
-                    crate::Error::MissingTx(_) if policy.skip_missing_data.unwrap_or(false) => {
-                        log::warn!("missing tx:{}", err);
-                        Ok(None)
-                    }
-                    crate::Error::CborError(_) if policy.skip_cbor_errors.unwrap_or(false) => {
-                        log::warn!("cbor error:{}", err);
-                        Ok(None)
-                    }
-                    crate::Error::LedgerError(_) if policy.skip_ledger_errors.unwrap_or(false) => {
-                        log::warn!("ledger error:{}", err);
-                        Ok(None)
-                    }
+                    crate::Error::MissingTx(_) => handle_error(err, &policy.missing_data),
+                    crate::Error::CborError(_) => handle_error(err, &policy.cbor_errors),
+                    crate::Error::LedgerError(_) => handle_error(err, &policy.ledger_errors),
                     _ => Err(err),
                 }
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ pub mod bootstrap;
 pub mod crosscut;
 pub mod enrich;
 pub mod model;
+pub mod prelude;
 pub mod reducers;
 pub mod sources;
 pub mod storage;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,0 +1,2 @@
+pub use crate::crosscut::policies::AppliesPolicy;
+pub use gasket::error::AsWorkError;

--- a/src/reducers/balance_by_address.rs
+++ b/src/reducers/balance_by_address.rs
@@ -1,20 +1,18 @@
-use crosscut::policies::*;
-use gasket::error::AsWorkError;
 use pallas::ledger::traverse::MultiEraOutput;
 use pallas::ledger::traverse::{MultiEraBlock, OutputRef};
 use serde::Deserialize;
 
-use crate::{crosscut, model};
+use crate::{crosscut, model, prelude::*};
 
 #[derive(Deserialize)]
 pub struct Config {
     pub key_prefix: Option<String>,
     pub filter: Option<Vec<String>>,
-    pub policy: Option<ReducerPolicy>,
 }
 
 pub struct Reducer {
     config: Config,
+    policy: crosscut::policies::RuntimePolicy,
     address_hrp: String,
 }
 
@@ -27,7 +25,7 @@ impl Reducer {
     ) -> Result<(), gasket::error::Error> {
         let inbound_tx = ctx
             .find_ref_tx(input.tx_id())
-            .apply_policy(&self.config.policy)
+            .apply_policy(&self.policy)
             .or_work_err()?;
 
         let inbound_tx = match inbound_tx {
@@ -38,7 +36,7 @@ impl Reducer {
         let output_tx = inbound_tx
             .output_at(input.tx_index() as usize)
             .ok_or(crate::Error::ledger("output index not found in tx"))
-            .apply_policy(&self.config.policy)
+            .apply_policy(&self.policy)
             .or_work_err()?;
 
         let output_tx = match output_tx {
@@ -98,7 +96,6 @@ impl Reducer {
         output: &mut super::OutputPort,
     ) -> Result<(), gasket::error::Error> {
         for tx in block.txs().into_iter() {
-
             for input in tx.inputs().iter().filter_map(|i| i.output_ref()) {
                 self.process_inbound_txo(&ctx, &input, output)
                     .or_work_err()?;
@@ -114,9 +111,14 @@ impl Reducer {
 }
 
 impl Config {
-    pub fn plugin(self, chain: &crosscut::ChainWellKnownInfo) -> super::Reducer {
+    pub fn plugin(
+        self,
+        chain: &crosscut::ChainWellKnownInfo,
+        policy: &crosscut::policies::RuntimePolicy,
+    ) -> super::Reducer {
         let reducer = Reducer {
             config: self,
+            policy: policy.clone(),
             address_hrp: chain.address_hrp.clone(),
         };
 

--- a/src/reducers/transactions_count_by_address.rs
+++ b/src/reducers/transactions_count_by_address.rs
@@ -1,20 +1,18 @@
 use std::collections::HashSet;
 
-use crosscut::policies::*;
-use gasket::error::AsWorkError;
 use pallas::ledger::traverse::{Feature, MultiEraBlock, OutputRef};
 use serde::Deserialize;
 
-use crate::{crosscut, model};
+use crate::{crosscut, model, prelude::*};
 
 #[derive(Deserialize)]
 pub struct Config {
     pub key_prefix: Option<String>,
-    pub policy: Option<ReducerPolicy>,
 }
 
 pub struct Reducer {
     config: Config,
+    policy: crosscut::policies::RuntimePolicy,
     address_hrp: String,
 }
 
@@ -38,33 +36,33 @@ impl Reducer {
     fn find_address_from_output_ref(
         &mut self,
         ctx: &model::BlockContext,
-        input: &OutputRef
+        input: &OutputRef,
     ) -> Result<Option<String>, gasket::error::Error> {
         let inbound_tx = ctx
-        .find_ref_tx(input.tx_id())
-        .apply_policy(&self.config.policy)
-        .or_work_err()?;
+            .find_ref_tx(input.tx_id())
+            .apply_policy(&self.policy)
+            .or_work_err()?;
 
         let inbound_tx = match inbound_tx {
             Some(x) => x,
-            None => { 
+            None => {
                 log::error!("Didn't find inbound_tx, tx_id:{}", input.tx_id());
-                return Result::Ok(None)
-            },
+                return Result::Ok(None);
+            }
         };
 
         let output_tx = inbound_tx
             .output_at(input.tx_index() as usize)
             .ok_or(crate::Error::ledger("output index not found in tx"))
-            .apply_policy(&self.config.policy)
+            .apply_policy(&self.policy)
             .or_work_err()?;
 
         match output_tx {
             Some(x) => return Result::Ok(Some(x.address(&self.address_hrp))),
-            None => { 
+            None => {
                 log::error!("Output index not found, index:{}", input.tx_index());
-                return Result::Ok(None)
-             }
+                return Result::Ok(None);
+            }
         }
     }
 
@@ -76,24 +74,29 @@ impl Reducer {
     ) -> Result<(), gasket::error::Error> {
         if block.era().has_feature(Feature::SmartContracts) {
             for tx in block.txs() {
-
                 let input_addresses: Vec<_> = tx
-                .inputs()
-                .iter()
-                .filter_map(|multi_era_input| { 
-                    let output_ref = multi_era_input.output_ref().unwrap();
+                    .inputs()
+                    .iter()
+                    .filter_map(|multi_era_input| {
+                        let output_ref = multi_era_input.output_ref().unwrap();
 
-                    let maybe_input_address = self.find_address_from_output_ref(ctx, &output_ref);
+                        let maybe_input_address =
+                            self.find_address_from_output_ref(ctx, &output_ref);
 
-                    match maybe_input_address {
-                        Ok(maybe_addr) => maybe_addr,
-                        Err(x) => {
-                            log::error!("Not found, tx_id:{}, index_at:{}, e:{}", output_ref.tx_id(), output_ref.tx_index(), x);
-                            None
+                        match maybe_input_address {
+                            Ok(maybe_addr) => maybe_addr,
+                            Err(x) => {
+                                log::error!(
+                                    "Not found, tx_id:{}, index_at:{}, e:{}",
+                                    output_ref.tx_id(),
+                                    output_ref.tx_index(),
+                                    x
+                                );
+                                None
+                            }
                         }
-                    }
-                })
-                .collect();
+                    })
+                    .collect();
 
                 let output_addresses: Vec<_> = tx
                     .outputs()
@@ -103,7 +106,8 @@ impl Reducer {
                     .collect();
 
                 let all_addresses = [&input_addresses[..], &output_addresses[..]].concat();
-                let all_addresses_deduped: HashSet<String> = HashSet::from_iter(all_addresses.iter().cloned());
+                let all_addresses_deduped: HashSet<String> =
+                    HashSet::from_iter(all_addresses.iter().cloned());
 
                 for address in all_addresses_deduped.iter() {
                     self.increment_for_address(address, output)?;
@@ -116,9 +120,14 @@ impl Reducer {
 }
 
 impl Config {
-    pub fn plugin(self, chain: &crosscut::ChainWellKnownInfo) -> super::Reducer {
+    pub fn plugin(
+        self,
+        chain: &crosscut::ChainWellKnownInfo,
+        policy: &crosscut::policies::RuntimePolicy,
+    ) -> super::Reducer {
         let reducer = Reducer {
             config: self,
+            policy: policy.clone(),
             address_hrp: chain.address_hrp.clone(),
         };
 

--- a/src/reducers/transactions_count_by_address_by_epoch.rs
+++ b/src/reducers/transactions_count_by_address_by_epoch.rs
@@ -1,22 +1,20 @@
 use pallas::ledger::traverse::{Feature, MultiEraBlock, OutputRef};
 use serde::Deserialize;
 
-use crosscut::policies::*;
-use crate::{crosscut, model};
+use crate::{crosscut, model, prelude::*};
 
-use gasket::error::AsWorkError;
 use std::collections::HashSet;
 
 #[derive(Deserialize)]
 pub struct Config {
     pub key_prefix: Option<String>,
-    pub policy: Option<ReducerPolicy>,
 }
 
 pub struct Reducer {
     config: Config,
     address_hrp: String,
     chain: crosscut::ChainWellKnownInfo,
+    policy: crosscut::policies::RuntimePolicy,
 }
 
 impl Reducer {
@@ -40,33 +38,33 @@ impl Reducer {
     fn find_address_from_output_ref(
         &mut self,
         ctx: &model::BlockContext,
-        input: &OutputRef
+        input: &OutputRef,
     ) -> Result<Option<String>, gasket::error::Error> {
         let inbound_tx = ctx
-        .find_ref_tx(input.tx_id())
-        .apply_policy(&self.config.policy)
-        .or_work_err()?;
+            .find_ref_tx(input.tx_id())
+            .apply_policy(&self.policy)
+            .or_work_err()?;
 
         let inbound_tx = match inbound_tx {
             Some(x) => x,
-            None => { 
+            None => {
                 log::error!("Didn't find inbound_tx, tx_id:{}", input.tx_id());
-                return Result::Ok(None)
-            },
+                return Result::Ok(None);
+            }
         };
 
         let output_tx = inbound_tx
             .output_at(input.tx_index() as usize)
             .ok_or(crate::Error::ledger("output index not found in tx"))
-            .apply_policy(&self.config.policy)
+            .apply_policy(&self.policy)
             .or_work_err()?;
 
         match output_tx {
             Some(x) => return Result::Ok(Some(x.address(&self.address_hrp))),
-            None => { 
+            None => {
                 log::error!("Output index not found, index:{}", input.tx_index());
-                return Result::Ok(None)
-             }
+                return Result::Ok(None);
+            }
         }
     }
 
@@ -80,24 +78,29 @@ impl Reducer {
             let epoch_no = crosscut::epochs::block_epoch(&self.chain, block);
 
             for tx in block.txs() {
-
                 let input_addresses: Vec<_> = tx
-                .inputs()
-                .iter()
-                .filter_map(|multi_era_input| { 
-                    let output_ref = multi_era_input.output_ref().unwrap();
+                    .inputs()
+                    .iter()
+                    .filter_map(|multi_era_input| {
+                        let output_ref = multi_era_input.output_ref().unwrap();
 
-                    let maybe_input_address = self.find_address_from_output_ref(ctx, &output_ref);
+                        let maybe_input_address =
+                            self.find_address_from_output_ref(ctx, &output_ref);
 
-                    match maybe_input_address {
-                        Ok(maybe_addr) => maybe_addr,
-                        Err(x) => {
-                            log::error!("Not found, tx_id:{}, index_at:{}, e:{}", output_ref.tx_id(), output_ref.tx_index(), x);
-                            None
+                        match maybe_input_address {
+                            Ok(maybe_addr) => maybe_addr,
+                            Err(x) => {
+                                log::error!(
+                                    "Not found, tx_id:{}, index_at:{}, e:{}",
+                                    output_ref.tx_id(),
+                                    output_ref.tx_index(),
+                                    x
+                                );
+                                None
+                            }
                         }
-                    }
-                })
-                .collect();
+                    })
+                    .collect();
 
                 let output_addresses: Vec<_> = tx
                     .outputs()
@@ -107,7 +110,8 @@ impl Reducer {
                     .collect();
 
                 let all_addresses = [&input_addresses[..], &output_addresses[..]].concat();
-                let all_addresses_deduped: HashSet<String> = HashSet::from_iter(all_addresses.iter().cloned());
+                let all_addresses_deduped: HashSet<String> =
+                    HashSet::from_iter(all_addresses.iter().cloned());
 
                 for address in all_addresses_deduped.iter() {
                     self.increment_for_address(address, epoch_no, output)?;
@@ -120,11 +124,16 @@ impl Reducer {
 }
 
 impl Config {
-    pub fn plugin(self, chain: &crosscut::ChainWellKnownInfo) -> super::Reducer {
+    pub fn plugin(
+        self,
+        chain: &crosscut::ChainWellKnownInfo,
+        policy: &crosscut::policies::RuntimePolicy,
+    ) -> super::Reducer {
         let reducer = Reducer {
             config: self,
             address_hrp: chain.address_hrp.clone(),
             chain: chain.clone(),
+            policy: policy.clone(),
         };
 
         super::Reducer::TransactionsCountByAddressByEpoch(reducer)


### PR DESCRIPTION
This PR introduces a new way to define pipeline-wide runtime policies to handle known errors.

The policy is configured by adding a top-level section in the toml such as this:

```
[policy]
missing_data = "Skip" | "Warn" | "Default"
cbor_errors = "Skip" | "Warn" | "Default"
ledger_errors = "Skip" | "Warn" | "Default"
any_error = "Skip" | "Warn" | "Default"
```