### PR TITLE
feat: implement filter for transaction properties

### DIFF
--- a/src/reducers/mod.rs
+++ b/src/reducers/mod.rs
@@ -57,7 +57,7 @@ impl Config {
             #[cfg(feature = "unstable")]
             Config::BalanceByAddress(c) => c.plugin(policy),
             #[cfg(feature = "unstable")]
-            Config::TxByHash(c) => c.plugin(),
+            Config::TxByHash(c) => c.plugin(policy),
             #[cfg(feature = "unstable")]
             Config::TxCountByAddress(c) => c.plugin(policy),
             #[cfg(feature = "unstable")]
@@ -138,7 +138,7 @@ impl Reducer {
             #[cfg(feature = "unstable")]
             Reducer::BalanceByAddress(x) => x.reduce_block(block, ctx, output),
             #[cfg(feature = "unstable")]
-            Reducer::TxByHash(x) => x.reduce_block(block, output),
+            Reducer::TxByHash(x) => x.reduce_block(block, ctx, output),
             #[cfg(feature = "unstable")]
             Reducer::TxCountByAddress(x) => x.reduce_block(block, ctx, output),
             #[cfg(feature = "unstable")]


### PR DESCRIPTION
Initially the only property is `is_valid` - you can filter to only process transactions which are invalid by using the config:

```
    "reducers": [
        {
            "type": "TxByHash",
            "key_prefix": "c1",
            "filter": {
                "transaction": {
                    "is_valid": false
                }
            }
        }
    ],
```

We also add the possibility of using filters with the `TxByHash` reducer.

In the future the transaction filter can be extended to match transactions which mint a certain asset in the `txmint` field, or transactions whose metadata contains a specific key.