### PR TITLE
feat: implement config option 'finalize' to specify when to stop processing blocks

### DIFF
--- a/src/bin/scrolls/daemon.rs
+++ b/src/bin/scrolls/daemon.rs
@@ -40,6 +40,7 @@ struct ConfigRoot {
     reducers: Vec<reducers::Config>,
     storage: storage::Config,
     intersect: crosscut::IntersectConfig,
+    finalize: Option<crosscut::FinalizeConfig>,
     chain: Option<ChainConfig>,
     policy: Option<crosscut::policies::RuntimePolicy>,
 }
@@ -105,7 +106,7 @@ pub fn run(args: &Args) -> Result<(), scrolls::Error> {
     let chain = config.chain.unwrap_or_default().into();
     let policy = config.policy.unwrap_or_default().into();
 
-    let source = config.source.bootstrapper(&chain, &config.intersect);
+    let source = config.source.bootstrapper(&chain, &config.intersect, &config.finalize);
 
     let enrich = config.enrich.unwrap_or_default().bootstrapper(&policy);
 

--- a/src/crosscut/args.rs
+++ b/src/crosscut/args.rs
@@ -148,6 +148,48 @@ impl IntersectConfig {
     }
 }
 
+/// Optional configuration to stop processing new blocks after processing:
+///   1. a block with the given hash
+///   2. the first block on or after a given absolute slot
+///   3. TODO: a total of X blocks 
+#[derive(Deserialize, Debug, Clone)]
+pub struct FinalizeConfig {
+    until_hash: Option<String>,
+    max_block_slot: Option<u64>,
+    // max_block_quantity: Option<u64>,
+}
+
+pub fn should_finalize(
+    config: &Option<FinalizeConfig>,
+    last_point: &Point,
+    // block_count: u64,
+) -> bool {
+    let config = match config {
+        Some(x) => x,
+        None => return false,
+    };
+
+    if let Some(expected) = &config.until_hash {
+        if let Point::Specific(_, current) = last_point {
+            return expected == &hex::encode(current);
+        }
+    }
+    
+    if let Some(max) = config.max_block_slot {
+        if last_point.slot_or_default() >= max {
+            return true;
+        }
+    }
+    
+    // if let Some(max) = config.max_block_quantity {
+    //     if block_count >= max {
+    //         return true;
+    //     }
+    // }
+
+    false
+}
+
 /// Well-known information about the blockhain network
 ///
 /// Some of the logic in Scrolls depends on particular characteristic of the

--- a/src/sources/mod.rs
+++ b/src/sources/mod.rs
@@ -27,7 +27,7 @@ impl Config {
     ) -> Bootstrapper {
         match self {
             Config::N2N(c) => Bootstrapper::N2N(c.bootstrapper(chain, intersect, finalize)),
-            Config::N2C(c) => Bootstrapper::N2C(c.bootstrapper(chain, intersect, finalize)), // TODO
+            Config::N2C(c) => Bootstrapper::N2C(c.bootstrapper(chain, intersect, finalize)),
         }
     }
 }

--- a/src/sources/mod.rs
+++ b/src/sources/mod.rs
@@ -23,10 +23,11 @@ impl Config {
         self,
         chain: &crosscut::ChainWellKnownInfo,
         intersect: &crosscut::IntersectConfig,
+        finalize: &Option<crosscut::FinalizeConfig>,
     ) -> Bootstrapper {
         match self {
-            Config::N2N(c) => Bootstrapper::N2N(c.bootstrapper(chain, intersect)),
-            Config::N2C(c) => Bootstrapper::N2C(c.bootstrapper(chain, intersect)),
+            Config::N2N(c) => Bootstrapper::N2N(c.bootstrapper(chain, intersect, finalize)),
+            Config::N2C(c) => Bootstrapper::N2C(c.bootstrapper(chain, intersect, finalize)), // TODO
         }
     }
 }

--- a/src/sources/n2c/chainsync.rs
+++ b/src/sources/n2c/chainsync.rs
@@ -21,7 +21,7 @@ struct ChainObserver {
     chain_tip: Gauge,
     finalize_config: Option<crosscut::FinalizeConfig>,
 }
-    
+
 impl ChainObserver {
     fn new(min_depth: usize, 
         block_count: Counter,

--- a/src/sources/n2c/chainsync.rs
+++ b/src/sources/n2c/chainsync.rs
@@ -19,10 +19,16 @@ struct ChainObserver {
     blocks: HashMap<Point, Vec<u8>>,
     block_count: Counter,
     chain_tip: Gauge,
+    finalize_config: Option<crosscut::FinalizeConfig>,
 }
-
+    
 impl ChainObserver {
-    fn new(min_depth: usize, block_count: Counter, chain_tip: Gauge, output: OutputPort) -> Self {
+    fn new(min_depth: usize, 
+        block_count: Counter,
+        chain_tip: Gauge,
+        output: OutputPort,
+        finalize_config: Option<crosscut::FinalizeConfig>,
+    ) -> Self {
         Self {
             min_depth,
             block_count,
@@ -30,6 +36,7 @@ impl ChainObserver {
             output,
             chain_buffer: Default::default(),
             blocks: Default::default(),
+            finalize_config
         }
     }
 }
@@ -66,6 +73,11 @@ impl chainsync::Observer<chainsync::BlockContent> for ChainObserver {
             self.output
                 .send(model::RawBlockPayload::roll_forward(block))?;
             self.block_count.inc(1);
+            
+            // evaluate if we should finalize the thread according to config
+            if crosscut::should_finalize(&self.finalize_config, &point) {
+                return Ok(chainsync::Continuation::DropOut);
+            }
         }
 
         // notify chain tip to the pipeline metrics
@@ -103,8 +115,8 @@ pub struct Worker {
     min_depth: usize,
     chain: crosscut::ChainWellKnownInfo,
     intersect: crosscut::IntersectConfig,
+    finalize: Option<crosscut::FinalizeConfig>,
     cursor: storage::Cursor,
-    //finalize_config: Option<FinalizeConfig>,
     agent: Option<MyAgent>,
     transport: Option<Transport>,
     output: OutputPort,
@@ -118,6 +130,7 @@ impl Worker {
         min_depth: usize,
         chain: crosscut::ChainWellKnownInfo,
         intersect: crosscut::IntersectConfig,
+        finalize: Option<crosscut::FinalizeConfig>,
         cursor: storage::Cursor,
         output: OutputPort,
     ) -> Self {
@@ -126,6 +139,7 @@ impl Worker {
             min_depth,
             chain,
             intersect,
+            finalize,
             cursor,
             output,
             agent: None,
@@ -162,6 +176,7 @@ impl gasket::runtime::Worker for Worker {
                 self.block_count.clone(),
                 self.chain_tip.clone(),
                 self.output.clone(),
+                self.finalize.clone(),
             ),
         )
         .apply_start()

--- a/src/sources/n2c/mod.rs
+++ b/src/sources/n2c/mod.rs
@@ -19,10 +19,12 @@ impl Config {
         self,
         chain: &crosscut::ChainWellKnownInfo,
         intersect: &crosscut::IntersectConfig,
+        finalize: &Option<crosscut::FinalizeConfig>,
     ) -> Bootstrapper {
         Bootstrapper {
             config: self,
             intersect: intersect.clone(),
+            finalize: finalize.clone(),
             chain: chain.clone(),
             output: Default::default(),
         }
@@ -32,6 +34,7 @@ impl Config {
 pub struct Bootstrapper {
     config: Config,
     intersect: crosscut::IntersectConfig,
+    finalize: Option<crosscut::FinalizeConfig>,
     chain: crosscut::ChainWellKnownInfo,
     output: OutputPort<model::RawBlockPayload>,
 }
@@ -48,6 +51,7 @@ impl Bootstrapper {
                 self.config.min_depth.unwrap_or(0),
                 self.chain,
                 self.intersect,
+                self.finalize,
                 cursor,
                 self.output,
             ),

--- a/src/sources/n2n/mod.rs
+++ b/src/sources/n2n/mod.rs
@@ -42,10 +42,12 @@ impl Config {
         self,
         chain: &crosscut::ChainWellKnownInfo,
         intersect: &crosscut::IntersectConfig,
+        finalize: &Option<crosscut::FinalizeConfig>,
     ) -> Bootstrapper {
         Bootstrapper {
             config: self,
             intersect: intersect.clone(),
+            finalize: finalize.clone(),
             chain: chain.clone(),
             output: Default::default(),
         }
@@ -55,6 +57,7 @@ impl Config {
 pub struct Bootstrapper {
     config: Config,
     intersect: crosscut::IntersectConfig,
+    finalize: Option<crosscut::FinalizeConfig>,
     chain: crosscut::ChainWellKnownInfo,
     output: OutputPort<model::RawBlockPayload>,
 }
@@ -75,6 +78,7 @@ impl Bootstrapper {
                 self.config.min_depth.unwrap_or(0),
                 self.chain.clone(),
                 self.intersect,
+                self.finalize,
                 cursor,
                 headers_out,
             ),


### PR DESCRIPTION
This implements a `finalize` configuration option similar to in Oura. You can use it to make Scrolls stop processing blocks after processing a block with a specified hash or the first block which was created on or after a specified absolute slot.

For example you would include the following in your config to stop processing new blocks after processing the block with hash `fafd996ddd3d2fdb2bf2a5dd5a3b32d0827fc53634871c85c5441959d7dae795`:
```
    "finalize": {
        "until_hash": "fafd996ddd3d2fdb2bf2a5dd5a3b32d0827fc53634871c85c5441959d7dae795"
    },
```

Or to stop processing new blocks after processing the first block which was created on or after slot `1713945`:
```
    "finalize": {
        "max_block_slot": 1713945
    },
```

Tested with N2N.
