### PR TITLE
fix: correct handling of collateral outputs for invalid transactions

### DIFF
--- a/src/reducers/balance_by_address.rs
+++ b/src/reducers/balance_by_address.rs
@@ -89,8 +89,8 @@ impl Reducer {
             self.process_inbound_txo(&ctx, &input, output)?;
         }
 
-        for (_idx, tx_output) in tx.outputs().iter().enumerate() {
-            self.process_outbound_txo(tx_output, output)?;
+        if let Some(coll_ret) = tx.collateral_return() {
+            self.process_outbound_txo(&coll_ret, output)?;
         }
 
         Ok(())

--- a/src/reducers/utxo_by_address.rs
+++ b/src/reducers/utxo_by_address.rs
@@ -97,9 +97,10 @@ impl Reducer {
         for input in tx.collateral().iter().map(|i| i.output_ref()) {
             self.process_inbound_txo(&ctx, &input, output)?;
         }
-
-        for (idx, tx_output) in tx.outputs().iter().enumerate() {
-            self.process_outbound_txo(tx, tx_output, idx, output)?;
+        
+        if let Some(coll_ret) = tx.collateral_return() {
+            let idx = tx.outputs().len();
+            self.process_outbound_txo(tx, &coll_ret, idx, output)?;
         }
 
         Ok(())


### PR DESCRIPTION
The current implementation processes the transaction outputs of an invalid transaction which means we can spoof balance of an address by creating an invalid transaction which sends that address funds as a txout, because these funds will be added to the address balance but actually this txout was was never created as the tx is invalid.

In this fix the collateral inputs are processed for invalid transactions as before, but now we do not process the txouts and instead check if there is a collateral return output (Babbage only) and if so we process that output as we would a normal txout.

Note that the txin of the collateral return output UTXO is defined in the ledger specification as `txhash:idx` where `idx` is the number of transaction outputs the tx has (in other words we create a UTXO in the next available index so as to not confuse with the normal transaction outputs which were not created): `let idx = tx.outputs().len();`