### PR TITLE
feat: redis transaction for all storage updates in block

### DIFF
--- a/src/storage/redis.rs
+++ b/src/storage/redis.rs
@@ -123,7 +123,10 @@ impl gasket::runtime::Worker for Worker {
 
         match msg.payload {
             model::CRDTCommand::BlockStarting(_) => {
-                // TODO: start transaction
+                // start redis transaction
+                redis::cmd("MULTI")
+                    .query(self.connection.as_mut().unwrap())
+                    .or_restart()?;
             }
             model::CRDTCommand::GrowOnlySetAdd(key, value) => {
                 self.connection
@@ -204,7 +207,12 @@ impl gasket::runtime::Worker for Worker {
                     .set("_cursor", &cursor_str)
                     .or_restart()?;
 
-                log::info!("new cursor saved to redis {}", &cursor_str)
+                log::info!("new cursor saved to redis {}", &cursor_str);
+                
+                // end redis transaction
+                redis::cmd("EXEC")
+                    .query(self.connection.as_mut().unwrap())
+                    .or_restart()?;
             }
         };
 


### PR DESCRIPTION
The comment suggests you planned to add this, and indeed it makes sense. This executes all the commands needed to process a particular block at once which means we can't query data as it is still being updated. This prevents, for example, race conditions when reading data while updating balances per transaction input/output.

The `redis` crate support for transactions does not seem suitable for our needs and also does not provide methods for the `MULTI` and `EXEC` commands required to perform a transaction, for this reason we manually create the commands. `MULTI` starts the transaction, and all commands that follow it are queued until a `EXEC` command is sent.

Is there any issues here where something might happen to prevent the `EXEC` to end the transaction being called?