### PR TITLE
feat: filter by address payment or delegation part

### DIFF
--- a/src/crosscut/filters.rs
+++ b/src/crosscut/filters.rs
@@ -34,24 +34,44 @@ impl AddressPattern {
             }
         }
 
-        if let Some(_) = &self.payment_hex {
-            // we need hex methods in Pallas addresses
-            todo!();
+        if let Some(x) = &self.payment_hex {
+            if let Address::Shelley(ref a) = addr {
+                let payment_hex = a.payment().to_hex();
+
+                if payment_hex.eq(x) {
+                    return true;
+                }
+            }
         }
 
-        if let Some(_) = &self.payment_bech32 {
-            // we need bech32 methods in Pallas addresses
-            todo!();
+        if let Some(x) = &self.payment_bech32 {
+            if let Address::Shelley(ref a) = addr {
+                if let Ok(payment_bech32) = a.payment().to_bech32() {
+                    if payment_bech32.eq(x) {
+                        return true;
+                    }
+                }
+            }
         }
 
-        if let Some(_) = &self.stake_hex {
-            // we need hex methods in Pallas addresses
-            todo!();
+        if let Some(x) = &self.stake_hex {
+            if let Address::Shelley(ref a) = addr {
+                let delegation_hex = a.delegation().to_hex();
+
+                if delegation_hex.eq(x) {
+                    return true;
+                }
+            }
         }
 
-        if let Some(_) = &self.stake_bech32 {
-            // we need bech32 methods in Pallas addresses
-            todo!();
+        if let Some(x) = &self.stake_bech32 {
+            if let Address::Shelley(ref a) = addr {
+                if let Ok(deleg_bech32) = a.delegation().to_bech32() {
+                    if deleg_bech32.eq(x) {
+                        return true;
+                    }
+                }
+            }
         }
 
         if let Some(x) = &self.is_script {


### PR DESCRIPTION
Implement filtering by address payment or delegation part, specified by hex or bech32. This will match any address which uses the given payment or delegation part. Note that using bech32 is more precise in the sense as this encoding contains information about whether the hash is of a pubkey or a script.

```
        {
          "type": "TxByHash",
          "key_prefix": "c1",
          "filter": {
            "address": {
                "payment_bech32": "addr_vkh1wdkle2sprqsuklt34474g6n4ps7k6pv6zwe4644uxmg7xj54y87"
            }
        }
```

You can use the [IO address demo](https://input-output-hk.github.io/cardano-addresses/demo/) to inspect parts of an address.

The bech32 prefixes use those from [CIP5](https://cips.cardano.org/cips/cip5/):
```
addr_vkh = payment part pubkeyhash
addr_shared_vkh = payment part scripthash
stake_vkh = stake part pubkeyhash
stake_shared_vkh = stake part script hash
```