### PR TITLE
fix: use correct TxIn index for CollRet UTxO

### DIFF
--- a/src/reducers/utxo_by_address.rs
+++ b/src/reducers/utxo_by_address.rs
@@ -82,8 +82,15 @@ impl Reducer {
                 self.process_consumed_txo(&ctx, &consumed, output)?;
             }
 
-            for (idx, produced) in tx.produces().iter().enumerate() {
-                self.process_produced_txo(&tx, produced, idx, output)?;
+            if tx.is_valid() {
+                for (idx, txo) in tx.outputs().iter().enumerate() {
+                    self.process_produced_txo(&tx, txo, idx, output)?;
+                }
+            } else {
+                if let Some(collret) = tx.collateral_return() {
+                    let idx = tx.outputs().len();
+                    self.process_produced_txo(&tx, &collret, idx, output)?;
+                }
             }
         }
 


### PR DESCRIPTION
It's kind of lame that we can't use `produced` but because we don't pass an index along with the TxOut when using `outputs` / `produced` / `collateral_return` we will have to continue using this pattern until we think of something better. For now I changed it to use `outputs` for readability, instead of using `produced` after already checking the validity.

The issue is that we either return the tx outputs or the collateral return output depending on the validity and then enumerate over them to get their indexes, but this gives the collateral return output UTxO an index of `0` when actually it is defined as the next available index after the tx outputs, `|txouts|`.