### PR TITLE
feat: full utxos by address

### DIFF
--- a/src/reducers/full_utxos_by_address.rs
+++ b/src/reducers/full_utxos_by_address.rs
@@ -1,0 +1,117 @@
+use pallas::codec::utils::CborWrap;
+use pallas::ledger::primitives::babbage::{DatumOption, PlutusData};
+use pallas::ledger::primitives::Fragment;
+use pallas::ledger::traverse::{Asset, MultiEraBlock, MultiEraTx};
+use pallas::ledger::traverse::{MultiEraOutput, OriginalHash};
+use serde::Deserialize;
+use serde_json::json;
+
+use crate::{crosscut, model, prelude::*};
+
+#[derive(Deserialize)]
+pub struct Config {
+    pub address: String,
+    pub prefix: Option<String>,
+}
+
+pub struct Reducer {
+    config: Config,
+    policy: crosscut::policies::RuntimePolicy,
+}
+
+pub fn resolve_datum(utxo: &MultiEraOutput, tx: &MultiEraTx) -> Result<PlutusData, ()> {
+    match utxo.datum() {
+        Some(DatumOption::Data(CborWrap(pd))) => Ok(pd),
+        Some(DatumOption::Hash(datum_hash)) => {
+            for raw_datum in tx.clone().plutus_data() {
+                if raw_datum.original_hash().eq(&datum_hash) {
+                    return Ok(raw_datum.clone().unwrap());
+                }
+            }
+
+            return Err(());
+        }
+        _ => Err(()),
+    }
+}
+
+impl Reducer {
+    fn get_key_value(&self, utxo: &MultiEraOutput, tx: &MultiEraTx) -> Option<(String, String)> {
+        if let Some(address) = utxo.address().map(|addr| addr.to_string()).ok() {
+            if address.eq(&self.config.address) {
+                let mut data = json!({
+                    "lovelace": utxo.lovelace_amount(),
+                });
+
+                if let Some(datum) = resolve_datum(utxo, tx).ok() {
+                    data["datum"] = serde_json::Value::String(hex::encode(
+                        datum.encode_fragment().ok().unwrap(),
+                    ));
+                } else if let Some(DatumOption::Hash(h)) = utxo.datum() {
+                    data["datum_hash"] = serde_json::Value::String(hex::encode(h.to_vec()));
+                }
+
+                let mut assets: serde_json::Map<String, serde_json::Value> = serde_json::Map::new();
+                for asset in utxo.non_ada_assets() {
+                    match asset {
+                        Asset::NativeAsset(cs, tkn, amt) => {
+                            let unit = format!("{}{}", hex::encode(cs.to_vec()), hex::encode(tkn));
+                            assets.insert(
+                                unit.clone(),
+                                json!({
+                                    "unit": unit,
+                                    "quantity": format!("{}", amt)
+                                }),
+                            );
+                        }
+                        _ => continue,
+                    }
+                }
+
+                data["amount"] = serde_json::Value::Object(assets);
+                return Some((address, data.to_string()));
+            }
+        }
+
+        None
+    }
+
+    pub fn reduce_block<'b>(
+        &mut self,
+        block: &'b MultiEraBlock<'b>,
+        ctx: &model::BlockContext,
+        output: &mut super::OutputPort,
+    ) -> Result<(), gasket::error::Error> {
+        let prefix = self.config.prefix.as_deref();
+        for tx in block.txs().into_iter() {
+            for consumed in tx.consumes().iter().map(|i| i.output_ref()) {
+                if let Some(Some(utxo)) = ctx.find_utxo(&consumed).apply_policy(&self.policy).ok() {
+                    if let Some((key, value)) = self.get_key_value(&utxo, &tx) {
+                        output.send(
+                            model::CRDTCommand::set_remove(prefix, &key.as_str(), value).into(),
+                        )?;
+                    }
+                }
+            }
+
+            for (_, produced) in tx.produces() {
+                if let Some((key, value)) = self.get_key_value(&produced, &tx) {
+                    output.send(model::CRDTCommand::set_add(None, &key, value).into())?;
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl Config {
+    pub fn plugin(self, policy: &crosscut::policies::RuntimePolicy) -> super::Reducer {
+        let reducer = Reducer {
+            config: self,
+            policy: policy.clone(),
+        };
+
+        super::Reducer::FullUtxosByAddress(reducer)
+    }
+}

--- a/src/reducers/full_utxos_by_address.rs
+++ b/src/reducers/full_utxos_by_address.rs
@@ -11,7 +11,7 @@ use crate::{crosscut, model, prelude::*};
 
 #[derive(Deserialize)]
 pub struct Config {
-    pub address: String,
+    pub filter: Vec<String>,
     pub prefix: Option<String>,
     pub address_as_key: Option<bool>,
 }
@@ -45,7 +45,7 @@ impl Reducer {
         output_ref: &(Hash<32>, u64),
     ) -> Option<(String, String)> {
         if let Some(address) = utxo.address().map(|addr| addr.to_string()).ok() {
-            if address.eq(&self.config.address) {
+            if self.config.filter.iter().any(|addr| address.eq(addr)) {
                 let mut data = serde_json::Value::Object(serde_json::Map::new());
                 let address_as_key = self.config.address_as_key.unwrap_or(false);
                 let key: String;

--- a/testdrive/full_utxos_by_address/daemon.toml
+++ b/testdrive/full_utxos_by_address/daemon.toml
@@ -8,7 +8,7 @@ db_path = "./data/sled_db"
 
 [[reducers]]
 type = "FullUtxosByAddress"
-address = "addr1z8snz7c4974vzdpxu65ruphl3zjdvtxw8strf2c2tmqnxz2j2c79gy9l76sdg0xwhd7r0c0kna0tycz4y5s6mlenh8pq0xmsha"
+filter = ["addr1z8snz7c4974vzdpxu65ruphl3zjdvtxw8strf2c2tmqnxz2j2c79gy9l76sdg0xwhd7r0c0kna0tycz4y5s6mlenh8pq0xmsha"]
 
 [storage]
 type = "Redis"

--- a/testdrive/full_utxos_by_address/daemon.toml
+++ b/testdrive/full_utxos_by_address/daemon.toml
@@ -9,6 +9,7 @@ db_path = "./data/sled_db"
 [[reducers]]
 type = "FullUtxosByAddress"
 filter = ["addr1z8snz7c4974vzdpxu65ruphl3zjdvtxw8strf2c2tmqnxz2j2c79gy9l76sdg0xwhd7r0c0kna0tycz4y5s6mlenh8pq0xmsha"]
+# address_as_key = false
 
 [storage]
 type = "Redis"

--- a/testdrive/full_utxos_by_address/daemon.toml
+++ b/testdrive/full_utxos_by_address/daemon.toml
@@ -1,0 +1,24 @@
+[source]
+type = "N2N"
+address = "preprod-node.world.dev.cardano.org:30000"
+
+[enrich]
+type = "Sled"
+db_path = "./data/sled_db"
+
+[[reducers]]
+type = "FullUtxosByAddress"
+address = "addr_test1xqtcjvyzs7t9c7zx9tks9ss682dymljr6kaxv0mgu2ljvhlhsecqwccjvxczaqetf20lt5vsxagku2cd5umjrewrgkfqagvy5e"
+
+[storage]
+type = "Redis"
+connection_params = "redis://redis:6379"
+
+[intersect]
+type = "Tip"
+
+[chain]
+type = "PreProd"
+
+[policy]
+missing_data = "Skip"

--- a/testdrive/full_utxos_by_address/daemon.toml
+++ b/testdrive/full_utxos_by_address/daemon.toml
@@ -1,6 +1,6 @@
 [source]
 type = "N2N"
-address = "preprod-node.world.dev.cardano.org:30000"
+address = "relays-new.cardano-mainnet.iohk.io:3001"
 
 [enrich]
 type = "Sled"
@@ -8,7 +8,7 @@ db_path = "./data/sled_db"
 
 [[reducers]]
 type = "FullUtxosByAddress"
-address = "addr_test1xqtcjvyzs7t9c7zx9tks9ss682dymljr6kaxv0mgu2ljvhlhsecqwccjvxczaqetf20lt5vsxagku2cd5umjrewrgkfqagvy5e"
+address = "addr1z8snz7c4974vzdpxu65ruphl3zjdvtxw8strf2c2tmqnxz2j2c79gy9l76sdg0xwhd7r0c0kna0tycz4y5s6mlenh8pq0xmsha"
 
 [storage]
 type = "Redis"
@@ -18,7 +18,7 @@ connection_params = "redis://redis:6379"
 type = "Tip"
 
 [chain]
-type = "PreProd"
+type = "Mainnet"
 
 [policy]
 missing_data = "Skip"

--- a/testdrive/full_utxos_by_address/data/.gitignore
+++ b/testdrive/full_utxos_by_address/data/.gitignore
@@ -1,0 +1,1 @@
+dump.rdb

--- a/testdrive/full_utxos_by_address/docker-compose.yml
+++ b/testdrive/full_utxos_by_address/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     links:
       - redis
   redis:
-    image: redis/redis-stack-server:latest
+    image: redis/redis-stack:latest
     volumes:
       - ./data:/data
     ports:

--- a/testdrive/full_utxos_by_address/docker-compose.yml
+++ b/testdrive/full_utxos_by_address/docker-compose.yml
@@ -1,0 +1,18 @@
+version: "3.7"
+
+services:
+  scrolls:
+    image: ghcr.io/txpipe/scrolls:latest
+    command: ["daemon"]
+    environment:
+      - RUST_LOG=info
+    volumes:
+      - ./daemon.toml:/etc/scrolls/daemon.toml
+    links:
+      - redis
+  redis:
+    image: redis
+    volumes:
+      - ./data:/data
+    ports:
+      - "6379:6379"

--- a/testdrive/full_utxos_by_address/docker-compose.yml
+++ b/testdrive/full_utxos_by_address/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
   scrolls:
-    image: ghcr.io/txpipe/scrolls:latest
+    image: local/scrolls:staging
     command: ["daemon"]
     environment:
       - RUST_LOG=info
@@ -11,8 +11,9 @@ services:
     links:
       - redis
   redis:
-    image: redis
+    image: redis/redis-stack-server:latest
     volumes:
       - ./data:/data
     ports:
       - "6379:6379"
+      - "8001:8001"


### PR DESCRIPTION
## Full Details of Utxos by Address

Currently, the implementation of `UtxoByAddress` only offers an insight of output references and not actual unspent transaction outputs (UTxOs) which consist of:

- transaction input (tx_hash + output_index)
- transaction output (address, value + datum hash/ inline datum)

This reducer named `FullUtxosByAddress` is capable of indexing one or more addresses and depending on its configuration creates matches under the respective address or alternatively, create a redis key based on the output reference and one respective transaction output.

It serializes redis set members in json and follows same schema that blockfrost is using for its [/addresses/<addr>/utxo endpoint](https://docs.blockfrost.io/#tag/Cardano-Addresses/paths/~1addresses~1%7Baddress%7D~1utxos/get).