### PR TITLE
Feat: Sorted Set Score Increment/Decrement

### DIFF
--- a/src/model.rs
+++ b/src/model.rs
@@ -131,6 +131,7 @@ pub enum CRDTCommand {
     SetRemove(Set, Member),
     SortedSetAdd(Set, Member, Delta),
     SortedSetRemove(Set, Member, Delta),
+    SortedSetScoreCounter(Set, Member, Delta),
     TwoPhaseSetAdd(Set, Member),
     TwoPhaseSetRemove(Set, Member),
     GrowOnlySetAdd(Set, Member),
@@ -196,6 +197,20 @@ impl CRDTCommand {
         };
 
         CRDTCommand::SortedSetRemove(key, member, delta)
+    }
+
+    pub fn sorted_set_score_counter(
+        prefix: Option<&str>,
+        key: &str,
+        member: String,
+        delta: i64,
+    ) -> CRDTCommand {
+        let key = match prefix {
+            Some(prefix) => format!("{}.{}", prefix, key),
+            None => key.to_string(),
+        };
+
+        CRDTCommand::SortedSetScoreCounter(key, member, delta)
     }
 
     pub fn any_write_wins<K, V>(prefix: Option<&str>, key: K, value: V) -> CRDTCommand

--- a/src/storage/redis.rs
+++ b/src/storage/redis.rs
@@ -180,6 +180,15 @@ impl gasket::runtime::Worker for Worker {
                     .srem(key, value)
                     .or_restart()?;
             }
+            model::CRDTCommand::SortedSetScoreCounter(key, value, delta) => {
+                log::debug!("increasing set [{}], member [{}] score by {}", key, value, delta);
+
+                self.connection
+                    .as_mut()
+                    .unwrap()
+                    .zincr(key, value, delta)
+                    .or_restart()?;
+            }
             model::CRDTCommand::LastWriteWins(key, value, ts) => {
                 log::debug!("last write for [{}], slot [{}]", key, ts);
 

--- a/src/storage/skip.rs
+++ b/src/storage/skip.rs
@@ -116,6 +116,9 @@ impl gasket::runtime::Worker for Worker {
                     delta
                 );
             }
+            model::CRDTCommand::SortedSetScoreCounter(key, value, delta) => {
+                log::debug!("increasing set [{}] value [{}] delta [{}]", key, value, delta)
+            }
             model::CRDTCommand::SetRemove(key, value) => {
                 log::debug!("removing from set [{}], value [{}]", key, value);
             }


### PR DESCRIPTION
I have one use-case in particular for applying a delta to a sorted set member score. The nice thing about `zincr` is that if the member is unset, it will set it to 0 and increment from there. Real clean.

Use case:

A sorted set of the format `prefix.{ADDRESS}` with asset (policy id + asset name fingerprint) members, scored by owned supply count. This provides an easy way to look up ownership + token counts by address or stake key for organized by a given policy id/asset id. In my case I will need to create a separate set of all fingerprints for a given policy id so I can do ownership lookups without scans.

I'm sure there are tons of simpler use-cases where this will be useful too.